### PR TITLE
Update emote player engine to allow use more complex 3D structures

### DIFF
--- a/src/lib/EmotePlayer.tsx
+++ b/src/lib/EmotePlayer.tsx
@@ -1,41 +1,12 @@
 import {BasePlayerModel} from "@/BasePlayerModel.tsx";
-import {useEffect, useRef, useState} from "react";
-import type {PlayerModelMesh} from "@/player";
-import type {Emote} from "@/emoteAnimation/types/animationJson";
-import {EmoteAnimationPlayer} from "@/emoteAnimation/EmoteAnimationPlayer.ts";
-import {useFrame} from "@react-three/fiber";
+import {useEffect} from "react";
 import {Euler} from "three";
+import {useEmotePlayer} from "@/hooks/useEmotePlayer.ts";
 
 Euler.DEFAULT_ORDER = "ZYX" as "XYZ";
 
 export default function EmotePlayer({ emote }: { emote: Emote }) {
-  const playerModelRef = useRef<PlayerModelMesh>(null);
-  const [player, setPlayer] = useState<EmoteAnimationPlayer | null>(null);
-
-
-  useFrame((_, delta) => {
-    delta *= 1;
-    if (player) {
-      player.update(delta as Second);
-    }
-  });
-
-  useEffect(() => {
-    if (player) {
-      player.restart();
-      player.playEmote(emote);
-      // @ts-ignore only for dev
-      window.anim = player.animation;
-    }
-  }, [emote, player]);
-
-  useEffect(() => {
-    if (playerModelRef.current) {
-      setPlayer(new EmoteAnimationPlayer(playerModelRef.current));
-      // @ts-ignore only for dev
-      window.mesh = playerModelRef.current;
-    }
-  }, []);
+  const [player, modelRef] = useEmotePlayer(emote);
 
   useEffect(() => {
     const toggle = (ev: KeyboardEvent) => {
@@ -52,6 +23,6 @@ export default function EmotePlayer({ emote }: { emote: Emote }) {
   }, [player]);
 
   return (
-    <BasePlayerModel ref={playerModelRef} />
+    <BasePlayerModel ref={modelRef} />
   );
 }

--- a/src/lib/bodyParts/Arms.tsx
+++ b/src/lib/bodyParts/Arms.tsx
@@ -1,7 +1,9 @@
-import {type Mesh, Vector2, Vector3, type Vector3Tuple} from "three";
+import {Vector2, Vector3, type Vector3Tuple} from "three";
 import {forwardRef} from "react";
 import type {BodyPartProps} from "@/bodyParts/bodyPart";
 import {BodyPartBase} from "@/bodyParts/BodyPartBase.tsx";
+import type {BodyPartRepresentation} from "@/player";
+import {useCubedBend} from "@/hooks/useCubedBend.ts";
 
 const ARM_SIZE = [4, 6, 4] as Vector3Tuple;
 const ARM_BEND_SIZE = ARM_SIZE.map((val) => val - 0.01) as Vector3Tuple;
@@ -11,10 +13,12 @@ const LEFT_BEND_POSITION = new Vector3(1, -4, 0);
 const LEFT_ARM_PIVOT_POINT_SHIFT = new Vector3(1, -1, 0);
 const LEFT_ARM_TEXTURE_START = new Vector2(32, 64 - 16);
 const LEFT_ARM_BEND_TEXTURE_START = new Vector2(32, 64 - 10);
-export const LeftArm = forwardRef<Mesh>(({children, name, debug, position}: BodyPartProps, ref) => {
+export const LeftArm = forwardRef<BodyPartRepresentation | undefined, BodyPartProps>(({children, name, debug, position}: BodyPartProps, ref) => {
+  const { baseRef, bendRef } = useCubedBend(ref);
+
   return (
     <BodyPartBase
-      ref={ref}
+      ref={baseRef}
       pivotShift={LEFT_ARM_PIVOT_POINT_SHIFT}
       partSize={ARM_BEND_SIZE}
       textureStart={LEFT_ARM_TEXTURE_START}
@@ -23,7 +27,7 @@ export const LeftArm = forwardRef<Mesh>(({children, name, debug, position}: Body
       position={position}
     >
       <BodyPartBase
-        ref={ref}
+        ref={bendRef}
         pivotShift={ARM_BEND_PIVOT_POINT_SHIFT}
         partSize={ARM_SIZE}
         textureStart={LEFT_ARM_BEND_TEXTURE_START}
@@ -42,10 +46,12 @@ const RIGHT_BEND_POSITION = new Vector3(-1, -4, 0);
 const RIGHT_ARM_PIVOT_POINT_SHIFT = new Vector3(-1, -1, 0);
 const RIGHT_ARM_TEXTURE_START = new Vector2(32 + 8,16);
 const RIGHT_ARM_BEND_TEXTURE_START = new Vector2(32 + 8,16 + 6);
-export const RightArm = forwardRef<Mesh, BodyPartProps>(({children, name, debug, position}: BodyPartProps, ref) => {
+export const RightArm = forwardRef<BodyPartRepresentation | undefined, BodyPartProps>(({children, name, debug, position}: BodyPartProps, ref) => {
+  const { baseRef, bendRef } = useCubedBend(ref);
+
   return (
     <BodyPartBase
-      ref={ref}
+      ref={baseRef}
       pivotShift={RIGHT_ARM_PIVOT_POINT_SHIFT}
       partSize={ARM_SIZE}
       textureStart={RIGHT_ARM_TEXTURE_START}
@@ -54,7 +60,7 @@ export const RightArm = forwardRef<Mesh, BodyPartProps>(({children, name, debug,
       position={position}
     >
       <BodyPartBase
-        ref={ref}
+        ref={bendRef}
         pivotShift={ARM_BEND_PIVOT_POINT_SHIFT}
         partSize={ARM_BEND_SIZE}
         textureStart={RIGHT_ARM_BEND_TEXTURE_START}

--- a/src/lib/bodyParts/Head.tsx
+++ b/src/lib/bodyParts/Head.tsx
@@ -1,15 +1,34 @@
 import {type Mesh, Vector2, Vector3, type Vector3Tuple} from "three";
-import {forwardRef} from "react";
+import {forwardRef, useImperativeHandle, useRef} from "react";
 import type {BodyPartProps} from "@/bodyParts/bodyPart";
 import {BodyPartBase} from "@/bodyParts/BodyPartBase.tsx";
+import type {BodyPartRepresentation} from "@/player";
 
 const PIVOT_POINT_SHIFT = new Vector3(0, 4, 0);
 const HEAD_SIZE = [8, 8, 8] as Vector3Tuple;
 const TEXTURE_START = new Vector2(0, 0);
 
-export const Head = forwardRef<Mesh, BodyPartProps>(({ name, debug, children, position }: BodyPartProps, ref) => {
+export const Head = forwardRef<BodyPartRepresentation | undefined, BodyPartProps>(({ name, debug, children, position }: BodyPartProps, ref) => {
+  const headRef = useRef<Mesh>(null);
+
+  useImperativeHandle(ref, () => {
+    if (headRef.current === null) {
+      return undefined;
+    }
+
+    const head = headRef.current;
+
+    return {
+      name: name,
+      uuid: head.uuid,
+      position: head.position,
+      rotation: head.rotation,
+      scale: head.scale
+    };
+  });
+
   return <BodyPartBase
-    ref={ref}
+    ref={headRef}
     pivotShift={PIVOT_POINT_SHIFT}
     partSize={HEAD_SIZE}
     textureStart={TEXTURE_START}

--- a/src/lib/bodyParts/Legs.tsx
+++ b/src/lib/bodyParts/Legs.tsx
@@ -1,7 +1,9 @@
-import {type Mesh, Vector2, Vector3, type Vector3Tuple} from "three";
+import {Vector2, Vector3, type Vector3Tuple} from "three";
 import {forwardRef} from "react";
 import type {BodyPartProps} from "@/bodyParts/bodyPart";
 import {BodyPartBase} from "@/bodyParts/BodyPartBase.tsx";
+import {useCubedBend} from "@/hooks/useCubedBend.ts";
+import type {BodyPartRepresentation} from "@/player";
 
 const LEG_SIZE = [4, 6, 4] as Vector3Tuple;
 const LEG_BEND_SIZE = LEG_SIZE.map((val) => val - 0.01) as Vector3Tuple;
@@ -10,10 +12,17 @@ const BEND_POSITION = new Vector3(0, -6, 0);
 
 const LEFT_LEG_TEXTURE_START = new Vector2(16, 64 - 16);
 const LEFT_LEG_BEND_TEXTURE_START = new Vector2(16, 64 - 10);
-export const LeftLeg = forwardRef<Mesh, BodyPartProps>(({children, name, debug, position}: BodyPartProps, ref) => {
+export const LeftLeg = forwardRef<BodyPartRepresentation | undefined, BodyPartProps>(({
+  children,
+  name,
+  debug,
+  position
+}: BodyPartProps, ref) => {
+  const { baseRef, bendRef } = useCubedBend(ref);
+
   return (
     <BodyPartBase
-      ref={ref}
+      ref={baseRef}
       pivotShift={LEG_PIVOT_POINT_SHIFT}
       partSize={LEG_SIZE}
       textureStart={LEFT_LEG_TEXTURE_START}
@@ -22,7 +31,7 @@ export const LeftLeg = forwardRef<Mesh, BodyPartProps>(({children, name, debug, 
       position={position}
     >
       <BodyPartBase
-        ref={ref}
+        ref={bendRef}
         pivotShift={LEG_PIVOT_POINT_SHIFT}
         partSize={LEG_BEND_SIZE}
         textureStart={LEFT_LEG_BEND_TEXTURE_START}
@@ -38,10 +47,17 @@ export const LeftLeg = forwardRef<Mesh, BodyPartProps>(({children, name, debug, 
 
 const RIGHT_LEG_TEXTURE_START = new Vector2(0, 16);
 const RIGHT_LEG_BEND_TEXTURE_START = new Vector2(0,16+6);
-export const RightLeg = forwardRef<Mesh>(({children, name, debug, position}: BodyPartProps, ref) => {
+export const RightLeg = forwardRef<BodyPartRepresentation | undefined, BodyPartProps>(({
+  children,
+  name,
+  debug,
+  position
+}: BodyPartProps, ref) => {
+  const { baseRef, bendRef } = useCubedBend(ref);
+
   return (
     <BodyPartBase
-      ref={ref}
+      ref={baseRef}
       pivotShift={LEG_PIVOT_POINT_SHIFT}
       partSize={LEG_SIZE}
       textureStart={RIGHT_LEG_TEXTURE_START}
@@ -50,7 +66,7 @@ export const RightLeg = forwardRef<Mesh>(({children, name, debug, position}: Bod
       position={position}
     >
       <BodyPartBase
-        ref={ref}
+        ref={bendRef}
         pivotShift={LEG_PIVOT_POINT_SHIFT}
         partSize={LEG_BEND_SIZE}
         textureStart={RIGHT_LEG_BEND_TEXTURE_START}

--- a/src/lib/bodyParts/bodyPart.d.ts
+++ b/src/lib/bodyParts/bodyPart.d.ts
@@ -2,16 +2,18 @@ import type {Euler, Vector3, Vector3Tuple} from "three";
 import type {ReactNode} from "react";
 
 type BodyPartProps = {
-  name?: BodyPart | string;
+  name: BodyPart | string;
   position?: Vector3 | Vector3Tuple;
   rotation?: Euler;
   debug?: boolean;
   children?: ReactNode;
 }
 
-type BodyPart = "head" |
-  "torso" | "torso_bend" |
-  "leftArm" | "leftArm_bend" |
-  "rightArm" | "rightArm_bend" |
-  "leftLeg" | "leftLeg_bend" |
-  "rightLeg" | "rightLeg_bend";
+type BodyParts = "head" | "torso" | "leftArm" | "rightArm" | "leftLeg" | "rightLeg";
+
+type BodyPartWithBend = BodyParts |
+  "torso_bend" |
+  "leftArm_bend" |
+  "rightArm_bend" |
+  "leftLeg_bend" |
+  "rightLeg_bend";

--- a/src/lib/emoteAnimation/EmoteAnimationPlayer.ts
+++ b/src/lib/emoteAnimation/EmoteAnimationPlayer.ts
@@ -2,7 +2,6 @@ import {Timeline} from "@/emoteAnimation/core/Timeline.ts";
 import {Animation} from "@/emoteAnimation/core/Animation.ts";
 import type {PlayerModelMesh} from "@/player";
 import {MeshUpdater} from "@/emoteAnimation/core/MeshUpdater.ts";
-import type {Emote, Update} from "@/emoteAnimation/types/animationJson";
 import {UpdatesBucket} from "@/emoteAnimation/core/UpdatesBucket.ts";
 
 export class EmoteAnimationPlayer {
@@ -54,7 +53,11 @@ export class EmoteAnimationPlayer {
       }
 
       this.animation.collectUpdates(t, this.updatesBucket);
-      this.meshUpdater.update();
+      try {
+        this.meshUpdater.update();
+      } catch {
+        this.updatesBucket.clear();
+      }
     }
   }
 }

--- a/src/lib/emoteAnimation/constants/index.ts
+++ b/src/lib/emoteAnimation/constants/index.ts
@@ -1,14 +1,11 @@
-import type {
-  MovePart,
-  PositionTransformationDir,
-  RotationTransformationDir,
-  TransformationDir
-} from "@/emoteAnimation/types/animationJson";
-
 export const MOVE_PARTS: MovePart[] = ["head", "leftArm", "leftLeg", "rightArm", "rightLeg", "torso"];
 
-export const MOVE_TRANSFORMS_DIR: TransformationDir[] = ["x", "y", "z", "pitch", "yaw", "roll"];
+export const MOVE_TRANSFORMS_DIR: TransformationDir[] = ["x", "y", "z", "pitch", "yaw", "roll", "scaleX", "scaleY", "scaleZ"];
 
 export const ROTATION_TRANSFORMS_DIR: RotationTransformationDir[] = ["pitch", "yaw", "roll"];
 
 export const POSITION_TRANSFORMS_DIR: PositionTransformationDir[] = ["x", "y", "z"];
+
+export const SCALE_TRANSFORM_DIR: ScaleTransformationDir[] = ["scaleY", "scaleX", "scaleZ"];
+
+export const MOVE_TRANSFORMS_DIR_WITH_BENDING: (TransformationDir|BendTransformationDir)[] = ["bend", "axis", ...MOVE_TRANSFORMS_DIR];

--- a/src/lib/emoteAnimation/core/Channel.ts
+++ b/src/lib/emoteAnimation/core/Channel.ts
@@ -1,36 +1,23 @@
-import type {EmoteKeyframe} from "@/emoteAnimation/core/EmoteKeyframe.ts";
-import type {KeyframePair, RotationTransformationDir, TransformationDir} from "@/emoteAnimation/types/animationJson";
-
-const rotationMap = {
-  "pitch": "x",
-  "roll": "z",
-  "yaw": "y",
-} as const;
-
-function isRotationTransformDir(dir: TransformationDir): dir is RotationTransformationDir {
-  return dir.length > 1;
-}
+import {getTransformTypeAndAxisByTransformDir} from "@/utils/getTransformTypeAndAxisByTransformDir.ts";
 
 export class Channel {
-  public readonly axis: "x" | "y" | "z";
-  public readonly transformType: "position" | "rotation";
-  private readonly keyframes: EmoteKeyframe[] = [];
+  public readonly axis: Axis;
+  public readonly transformType: TransformationType;
+  private readonly keyframes: IEmoteKeyframe[] = [];
   private cursor = 0;
 
-  constructor(transformationDir: TransformationDir, keyframes: EmoteKeyframe[]) {
-    this.transformType = "position";
-    if (isRotationTransformDir(transformationDir)) {
-      this.transformType = "rotation";
-      transformationDir = rotationMap[transformationDir];
-    }
+  constructor(transformationDir: MoveTransformationDir, keyframes: IEmoteKeyframe[]) {
+    const { axis, transformType} = getTransformTypeAndAxisByTransformDir(transformationDir);
 
-    this.axis = transformationDir;
+    this.transformType = transformType;
+    this.axis = axis;
+
     this.keyframes.push({
       tick: 0,
       easing: keyframes[0]?.easing || "LINEAR",
+      value: 0,
       axis: this.axis,
       transformType: this.transformType,
-      value: 0,
     });
     this.keyframes.push(...keyframes.filter((kf) => kf.transformType === this.transformType && kf.axis === this.axis));
   }

--- a/src/lib/emoteAnimation/core/EmoteKeyframe.ts
+++ b/src/lib/emoteAnimation/core/EmoteKeyframe.ts
@@ -1,38 +1,20 @@
-import type {
-  IEmoteKeyframe, Move,
-  MovePart,
-  TransformationDir
-} from "@/emoteAnimation/types/animationJson";
-import {isRotationTransformDir} from "@/utils/typeGuards/isRotationTransformDir.ts";
-
-const rotationMap = {
-  "pitch": "x",
-  "yaw": "y",
-  "roll": "z"
-} as const;
+import {getTransformTypeAndAxisByTransformDir} from "@/utils/getTransformTypeAndAxisByTransformDir.ts";
 
 export class EmoteKeyframe implements IEmoteKeyframe{
   public readonly tick;
   public readonly easing;
   public readonly value;
-  public readonly transformType: "position" | "rotation";
+  public readonly transformType;
   public readonly axis;
 
-  constructor(move: Move, part: MovePart, dir: TransformationDir | "bend") {
+  constructor(move: Move, part: MovePart, dir: MoveTransformationDir) {
     this.tick = move.tick;
     this.easing = move.easing;
     this.value = move[part]![dir] || 0;
 
-    if (dir === "bend") {
-      dir = "pitch";
-    }
+    const { axis, transformType } = getTransformTypeAndAxisByTransformDir(dir);
 
-    this.transformType = "position";
-    if (isRotationTransformDir(dir)) {
-      this.transformType = "rotation";
-      dir = rotationMap[dir];
-    }
-
-    this.axis = dir;
+    this.axis = axis;
+    this.transformType = transformType;
   }
 }

--- a/src/lib/emoteAnimation/core/MeshUpdater.ts
+++ b/src/lib/emoteAnimation/core/MeshUpdater.ts
@@ -1,6 +1,4 @@
 import type {PlayerModelMesh} from "@/player";
-import type {Update} from "@/emoteAnimation/types/animationJson";
-import type {BodyPart} from "@/bodyParts/bodyPart";
 import {warn} from "@/utils/warn.ts";
 import type {UpdatesBucket} from "@/emoteAnimation/core/UpdatesBucket.ts";
 
@@ -30,11 +28,17 @@ export class MeshUpdater {
 
     const rotation = mesh.rotation;
     const position = mesh.position;
+    const bend = mesh.bendRotation;
+    const scale = mesh.scale;
 
     if (transformType === "rotation") {
       rotation[axis] = value;
-    } else {
+    } else if (transformType === "position") {
       position[axis] = value * POSITION_RATIO;
+    } else if (transformType === "scale") {
+      scale[axis] = value;
+    } else if (bend) {
+      bend[axis] = value;
     }
   }
 
@@ -49,7 +53,10 @@ export class MeshUpdater {
 
   reset() {
     for (const part in this.playerMesh) {
-      const mesh = this.playerMesh[part as BodyPart];
+      const mesh = this.playerMesh[part as keyof PlayerModelMesh];
+      if (mesh === undefined) {
+        continue;
+      }
       mesh.position.multiplyScalar(0);
       mesh.rotation.set(0,0,0);
     }

--- a/src/lib/emoteAnimation/core/Track.ts
+++ b/src/lib/emoteAnimation/core/Track.ts
@@ -1,17 +1,21 @@
-import type {BodyPart} from "@/bodyParts/bodyPart";
 import {Channel} from "@/emoteAnimation/core/Channel.ts";
 import type {EmoteKeyframe} from "@/emoteAnimation/core/EmoteKeyframe.ts";
-import type {TransformationDir, Update} from "@/emoteAnimation/types/animationJson";
 import {Interpolator} from "@/emoteAnimation/core/Interpolator.ts";
 import type {UpdatesBucket} from "@/emoteAnimation/core/UpdatesBucket.ts";
 
-const TRANSFORMATION_DIR: TransformationDir[] = ["x", "y", "z", "pitch", "roll", "yaw"];
+const TRANSFORMATION_DIR: MoveTransformationDir[] = [
+  "x", "y", "z",
+  "pitch", "roll", "yaw",
+  "scaleX", "scaleY", "scaleZ",
+  "bend", "axis"
+];
+
 
 export class Track {
-  public readonly target: BodyPart;
-  private channels: Channel[];
+  public readonly target: MovePart;
+  private readonly channels: Channel[];
 
-  constructor(target: BodyPart, keyframes: EmoteKeyframe[]) {
+  constructor(target: MovePart, keyframes: EmoteKeyframe[]) {
     this.target = target;
     this.channels = TRANSFORMATION_DIR.map((dir) => new Channel(dir, keyframes));
   }

--- a/src/lib/emoteAnimation/types/animationJson.d.ts
+++ b/src/lib/emoteAnimation/types/animationJson.d.ts
@@ -1,11 +1,15 @@
-import type {BodyPart} from "@/bodyParts/bodyPart";
-
 type MovePart = "head" | "torso" | "leftLeg" | "rightLeg" | "leftArm" | "rightArm";
 
-type PositionTransformationDir = "x" | "y" | "z";
-type RotationTransformationDir = "pitch" | "yaw" | "roll";
-type TransformationDir = PositionTransformationDir | RotationTransformationDir;
+type Axis = "x" | "y" | "z"
 
+type PositionTransformationDir = Axis;
+type RotationTransformationDir = "pitch" | "yaw" | "roll";
+type ScaleTransformationDir = "scaleX" | "scaleY" |"scaleZ";
+type BendTransformationDir = "bend" | "axis";
+type TransformationDir = PositionTransformationDir | RotationTransformationDir | ScaleTransformationDir;
+type MoveTransformationDir = TransformationDir | BendTransformationDir
+
+type TransformationType = "position" | "rotation" | "scale" | "bend";
 
 type MoveBase = {
   tick: number,
@@ -14,7 +18,7 @@ type MoveBase = {
 }
 
 type EmoteTransformation = {
-  [V in (TransformationDir | "bend")]?: number
+  [V in (MoveTransformationDir)]?: number
 }
 
 type MoveData = {
@@ -53,8 +57,8 @@ type IEmoteKeyframe = {
   tick: number,
   easing: string,
   value: number,
-  axis: "x" | "y" | "z",
-  transformType: "position" | "rotation",
+  axis: Axis,
+  transformType: TransformationType,
 }
 
 type KeyframePair = {
@@ -64,7 +68,7 @@ type KeyframePair = {
 
 type Update = {
   axis: PositionTransformationDir,
-  transformType: "position" | "rotation",
-  target: BodyPart,
+  transformType: TransformationType,
+  target: MovePart,
   value: number
 }

--- a/src/lib/hooks/useCubedBend.ts
+++ b/src/lib/hooks/useCubedBend.ts
@@ -1,0 +1,33 @@
+import {type ForwardedRef, useImperativeHandle, useRef} from "react";
+import type {Mesh} from "three";
+import type {BodyPartRepresentation} from "@/player";
+
+/**
+ * Bind to passed ref built BodyPartRepresentation, to work correctly you should bind both output refs
+ * to your body part meshes
+ * @param ref
+ */
+export function useCubedBend(ref: ForwardedRef<BodyPartRepresentation | undefined>) {
+  const baseRef = useRef<Mesh>(null);
+  const bendRef = useRef<Mesh>(null);
+
+  useImperativeHandle(ref, () => {
+    if (baseRef.current === null || bendRef.current === null) {
+      return undefined;
+    }
+
+    const base = baseRef.current;
+    const bend = bendRef.current;
+
+    return {
+      name: base.name,
+      uuid: base.uuid,
+      position: base.position,
+      rotation: base.rotation,
+      scale: base.scale,
+      bendRotation: bend.rotation,
+    };
+  });
+
+  return { baseRef, bendRef };
+}

--- a/src/lib/hooks/useEmotePlayer.ts
+++ b/src/lib/hooks/useEmotePlayer.ts
@@ -1,0 +1,31 @@
+import {useEffect, useRef, useState} from "react";
+import {EmoteAnimationPlayer} from "@/emoteAnimation/EmoteAnimationPlayer.ts";
+import {useFrame} from "@react-three/fiber";
+import type {PlayerModelMesh} from "@/player";
+
+export function useEmotePlayer(emote: Emote) {
+  const modelRef = useRef<PlayerModelMesh>(null);
+  const [player, setPlayer] = useState<EmoteAnimationPlayer | null>(null);
+
+  useFrame((_, delta) => {
+    delta *= 1;
+    if (player) {
+      player.update(delta as Second);
+    }
+  });
+
+  useEffect(() => {
+    if (player) {
+      player.restart();
+      player.playEmote(emote);
+    }
+  }, [emote, player]);
+
+  useEffect(() => {
+    if (modelRef.current) {
+      setPlayer(new EmoteAnimationPlayer(modelRef.current));
+    }
+  }, []);
+
+  return [player, modelRef] as const;
+}

--- a/src/lib/player.d.ts
+++ b/src/lib/player.d.ts
@@ -1,5 +1,15 @@
 import type {BodyPart, BodyPartProps} from "@/bodyParts/bodyPart";
-import type {Mesh} from "three";
+import {type Euler, type Vector3} from "three";
 
-type Pose = Partial<Record<BodyPart, BodyPartProps>>;
-type PlayerModelMesh = Record<BodyPart, Mesh>
+type Pose = Partial<Record<BodyPart, Omit<BodyPartProps, "name">>>;
+
+interface BodyPartRepresentation {
+  name: string,
+  uuid: string,
+  position: Vector3,
+  rotation: Euler,
+  scale: Vector3,
+  bendRotation?: Euler,
+}
+
+type PlayerModelMesh = Record<MovePart, BodyPartRepresentation>;

--- a/src/lib/utils/getTransformTypeAndAxisByTransformDir.ts
+++ b/src/lib/utils/getTransformTypeAndAxisByTransformDir.ts
@@ -1,0 +1,34 @@
+import {isRotationTransformDir} from "@/utils/typeGuards/isRotationTransformDir.ts";
+import {isScaleTransformationDir} from "@/utils/typeGuards/isScaleTransformationDir.ts";
+
+const rotationMap = {
+  "pitch": "x",
+  "roll": "z",
+  "yaw": "y",
+} as const;
+
+const scaleMap = {
+  "scaleX": "x",
+  "scaleY": "y",
+  "scaleZ": "z",
+} as const;
+
+export function getTransformTypeAndAxisByTransformDir(dir: MoveTransformationDir) {
+  let axis: Axis;
+  let transformType: TransformationType = "position";
+
+  if (isRotationTransformDir(dir)) {
+    transformType = "rotation";
+    axis = rotationMap[dir];
+  } else if (isScaleTransformationDir(dir)) {
+    transformType = "scale";
+    axis = scaleMap[dir];
+  } else if (dir === "bend" || dir === "axis") {
+    transformType = "bend";
+    axis = dir === "bend" ? "x" : "z";
+  } else {
+    axis = dir;
+  }
+
+  return { axis, transformType };
+}

--- a/src/lib/utils/typeGuards/isRotationTransformDir.ts
+++ b/src/lib/utils/typeGuards/isRotationTransformDir.ts
@@ -1,5 +1,5 @@
-import type {RotationTransformationDir, TransformationDir} from "@/emoteAnimation/types/animationJson";
+import {ROTATION_TRANSFORMS_DIR} from "@/emoteAnimation/constants";
 
-export function isRotationTransformDir(dir: TransformationDir): dir is RotationTransformationDir {
-  return dir.length > 1;
+export function isRotationTransformDir(dir: MoveTransformationDir): dir is RotationTransformationDir {
+  return ROTATION_TRANSFORMS_DIR.includes(dir as RotationTransformationDir);
 }

--- a/src/lib/utils/typeGuards/isScaleTransformationDir.ts
+++ b/src/lib/utils/typeGuards/isScaleTransformationDir.ts
@@ -1,0 +1,3 @@
+export function isScaleTransformationDir(dir: MoveTransformationDir): dir is ScaleTransformationDir {
+  return dir[0] === "s";
+}


### PR DESCRIPTION
In this PR include huge animation engine refactor. Now `MeshUpdater `manipulate objects due `MovePartRepesentation ` which allow more complex manipulation and mesh assigning. Also added new tracks to support scale transformation, bend modification now applies via appropriate `MovePart ` (no more `<part_name>_bend` tracks).